### PR TITLE
kernel/GNUmakefile: fix cargo invocation

### DIFF
--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -4,7 +4,7 @@ override MAKEFLAGS += -rR
 # Default target.
 .PHONY: all
 all:
-	cargo build --target x86_64-unknown-none
+	cargo +nightly --config build.rustflags=\"-C\ no-redzone=y\ -C\ panic=abort\ -C\ relocation-model=pic\ -C\ code-model=kernel\" build -Z build-std=core,compiler_builtins --target x86_64-unknown-none
 	cp target/x86_64-unknown-none/debug/limine-rust-barebones kernel.elf
 
 # Remove object files and the final executable.


### PR DESCRIPTION
With the previous command, there would be a lot of errors like these:

```
error[E0463]: can't find crate for `core`
  |
  = note: the `x86_64-unknown-none` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-none`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `compiler_builtins`
```

At least -Z build-std=core,compiler_builtins is necessary to make this build. And for that, a nightly cargo is needed.
For kernels, a few more options have been added, just to be sure.