### PR TITLE
use mtools instead of mounting the disk image

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,20 +56,13 @@ $(IMAGE_NAME).hdd: limine kernel
 	rm -f $(IMAGE_NAME).hdd
 	dd if=/dev/zero bs=1M count=0 seek=64 of=$(IMAGE_NAME).hdd
 	parted -s $(IMAGE_NAME).hdd mklabel gpt
-	parted -s $(IMAGE_NAME).hdd mkpart ESP fat32 2048s 100%
+	parted -s $(IMAGE_NAME).hdd mkpart ESP fat32 1MiB 100%
 	parted -s $(IMAGE_NAME).hdd set 1 esp on
 	./limine/limine bios-install $(IMAGE_NAME).hdd
-	sudo losetup -Pf --show $(IMAGE_NAME).hdd >loopback_dev
-	sudo mkfs.fat -F 32 `cat loopback_dev`p1
-	mkdir -p img_mount
-	sudo mount `cat loopback_dev`p1 img_mount
-	sudo mkdir -p img_mount/EFI/BOOT
-	sudo cp -v kernel/kernel.elf limine.cfg limine/limine-bios.sys img_mount/
-	sudo cp -v limine/BOOT*.EFI img_mount/EFI/BOOT/
-	sync
-	sudo umount img_mount
-	sudo losetup -d `cat loopback_dev`
-	rm -rf loopback_dev img_mount
+	mformat -i $(IMAGE_NAME).hdd@@1M
+	mmd -i $(IMAGE_NAME).hdd@@1M ::/EFI ::/EFI/BOOT
+	mcopy -i $(IMAGE_NAME).hdd@@1M kernel/kernel.elf limine.cfg limine/limine-bios.sys ::/
+	mcopy -i $(IMAGE_NAME).hdd@@1M limine/BOOT*.EFI ::/EFI/BOOT
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This avoids the need for sudo. The downside of this approach is obviously that it requires [Mtools](https://www.gnu.org/software/mtools/) be installed.