### PR TITLE
fix(kernel): remove the use of `offset` with a `usize` casted to an `…

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -30,11 +30,7 @@ unsafe extern "C" fn _start() -> ! {
             // We can safely unwrap the result of `as_ptr()` because the framebuffer address is
             // guaranteed to be provided by the bootloader.
             unsafe {
-                *(framebuffer
-                    .address
-                    .as_ptr()
-                    .unwrap()
-                    .offset(pixel_offset as isize) as *mut u32) = 0xFFFFFFFF;
+                *(framebuffer.address.as_ptr().unwrap().add(pixel_offset) as *mut u32) = 0xFFFFFFFF;
             }
         }
     }


### PR DESCRIPTION
…isize`

makes clippy happy :)

https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.add