### PR TITLE
Limine request statics should have the #[used] attribute

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -8,8 +8,11 @@ use limine::BaseRevision;
 
 /// Sets the base revision to the latest revision supported by the crate.
 /// See specification for further info.
+// Be sure to mark all limine requests with #[used], otherwise they may not end up in the final binary.
+#[used]
 static BASE_REVISION: BaseRevision = BaseRevision::new();
 
+#[used]
 static FRAMEBUFFER_REQUEST: FramebufferRequest = FramebufferRequest::new();
 
 #[no_mangle]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -8,7 +8,7 @@ use limine::BaseRevision;
 
 /// Sets the base revision to the latest revision supported by the crate.
 /// See specification for further info.
-// Be sure to mark all limine requests with #[used], otherwise they may not end up in the final binary.
+// Be sure to mark all limine requests with #[used], otherwise they may be removed by the compiler.
 #[used]
 static BASE_REVISION: BaseRevision = BaseRevision::new();
 
@@ -17,6 +17,8 @@ static FRAMEBUFFER_REQUEST: FramebufferRequest = FramebufferRequest::new();
 
 #[no_mangle]
 unsafe extern "C" fn _start() -> ! {
+    // All limine requests must also be referenced in a called function, otherwise they may be
+    // removed by the linker.
     assert!(BASE_REVISION.is_supported());
 
     if let Some(framebuffer_response) = FRAMEBUFFER_REQUEST.get_response() {


### PR DESCRIPTION
Without the `#[used]` attribute, the compiler is free to remove limine request statics from the final binary, and it does so when compiling with the release profile. This adds the attributes and fixes #6.