### PR TITLE
Use linker script file relative to Cargo.toml

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,7 +1,13 @@
+use std::path::PathBuf;
+
 fn main() {
     let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let linker_file = PathBuf::from(dir).join(format!("linker-{}.ld", arch));
+    let linker_file = linker_file.to_str().unwrap();
+
     // Tell cargo to pass the linker script to the linker..
-    println!("cargo:rustc-link-arg=-Tlinker-{arch}.ld");
+    println!("cargo:rustc-link-arg=-T{}", linker_file);
     // ..and to re-run if it changes.
-    println!("cargo:rerun-if-changed=linker-{arch}.ld");
+    println!("cargo:rerun-if-changed={}", linker_file);
 }


### PR DESCRIPTION
Makes it work even when you have a workspace and a folder called `kernel` inside the workspace which contains the linker file.